### PR TITLE
Use "after" for pull_request event 

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,4 +31,6 @@ try {
   });
 } catch (error) {
   core.setFailed(error.message);
+  // When we error, we set modified to true to make sure the tests run.
+  core.setOutput('modified', true);
 }

--- a/index.js
+++ b/index.js
@@ -18,6 +18,8 @@ const minimatch = require('minimatch');
     core.info(JSON.stringify(github.context.payload, null, 2));
   }
 
+  core.info(JSON.stringify(github.context.payload, null, 2));
+
   if (!ref) {
     core.setOutput('modified', true);
     return

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const minimatch = require('minimatch');
   const ghToken = core.getInput('github_token');
   const octokit = new Octokit(ghToken ? { auth: ghToken } : {});
   const paths = core.getInput('paths').split(',');
+  core.info(JSON.stringify(paths, null, 2));
 
   // When using pull_request, the context payload.head_commit is undefined. But we have after instead.
   let ref;
@@ -21,6 +22,7 @@ const minimatch = require('minimatch');
   core.info(JSON.stringify(github.context.payload, null, 2));
 
   if (!ref) {
+    core.info('failed to get ref');
     core.setOutput('modified', true);
     return
   }
@@ -28,6 +30,7 @@ const minimatch = require('minimatch');
   const [owner, repo] = github.context.payload.repository.full_name.split('/');
   const { data: { files }, err } = await octokit.repos.getCommit({ owner, repo, ref })
   if (err) {
+    core.info('got error')
     core.error(err);
     core.setOutput('modified', true);
     return
@@ -35,6 +38,7 @@ const minimatch = require('minimatch');
 
   if (Array.isArray(files)) {
     const modifiedPaths = files.map(f => f.filename);
+    core.info(JSON.stringify(modifiedPaths, null, 2));
     const modified = paths.some(p => minimatch.match(modifiedPaths, p).length);
     core.setOutput('modified', modified);
     return

--- a/index.js
+++ b/index.js
@@ -12,6 +12,8 @@ async(() => {
   const ref = github.context.payload.head_commit ?
     github.context.payload.head_commit.id : github.context.payload.after;
 
+  core.info(JSON.stringify(github.context.payload, null, 2));
+
   if (!ref) {
     core.setOutput('modified', true);
     return
@@ -20,7 +22,7 @@ async(() => {
   const [owner, repo] = github.context.payload.repository.full_name.split('/');
   const { data: { files }, err } = await octokit.repos.getCommit({ owner, repo, ref })
   if (err) {
-    console.error(err);
+    core.error(err);
     core.setOutput('modified', true);
     return
   }

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ try {
   const returnFiles = core.getInput('return_files') === 'true';
   // When using pull_request, the context payload.head_commit is undefined. But we have after instead.
   const ref = github.context.payload.head_commit ?
-    github.context.payload.head_commit.id : github.context.payload;
+    github.context.payload.head_commit.id : github.context.payload.after;
   const [owner, repo] = github.context.payload.repository.full_name.split('/');
   octokit.repos.getCommit({ owner, repo, ref })
     .then(({ data: { files } }, err) => {

--- a/index.js
+++ b/index.js
@@ -25,15 +25,8 @@ const minimatch = require('minimatch');
     repo = parts[1];
   }
 
-  try {
-    ref = github.context.payload.head_commit ?
-      github.context.payload.head_commit.id : github.context.payload.pull_request.base.sha;
-  } catch {
-    core.info(JSON.stringify(github.context.payload, null, 2));
-  }
-
   if (!ref) {
-    core.info('failed to get ref');
+    core.info(JSON.stringify(github.context.payload, null, 2));
     core.setOutput('modified', true);
     return
   }

--- a/index.js
+++ b/index.js
@@ -8,7 +8,9 @@ try {
   const octokit = new Octokit(ghToken ? { auth: ghToken } : {});
   const paths = core.getInput('paths').split(',');
   const returnFiles = core.getInput('return_files') === 'true';
-  const ref = github.context.payload.head_commit.id;
+  // When using pull_request, the context payload.head_commit is undefined. But we have after instead.
+  const ref = github.context.payload.head_commit ?
+    github.context.payload.head_commit.id : github.context.payload;
   const [owner, repo] = github.context.payload.repository.full_name.split('/');
   octokit.repos.getCommit({ owner, repo, ref })
     .then(({ data: { files } }, err) => {

--- a/index.js
+++ b/index.js
@@ -9,10 +9,14 @@ const minimatch = require('minimatch');
   const paths = core.getInput('paths').split(',');
 
   // When using pull_request, the context payload.head_commit is undefined. But we have after instead.
-  const ref = github.context.payload.head_commit ?
-    github.context.payload.head_commit.id : github.context.payload.after;
+  let ref;
 
-  core.info(JSON.stringify(github.context.payload, null, 2));
+  try {
+    ref = github.context.payload.head_commit ?
+      github.context.payload.head_commit.id : github.context.payload.pull_request.base.sha;
+  } catch {
+    core.info(JSON.stringify(github.context.payload, null, 2));
+  }
 
   if (!ref) {
     core.setOutput('modified', true);
@@ -28,6 +32,7 @@ const minimatch = require('minimatch');
   }
 
   if (Array.isArray(files)) {
+    const modifiedPaths = files.map(f => f.filename);
     const modified = paths.some(p => minimatch.match(modifiedPaths, p).length);
     core.setOutput('modified', modified);
     return

--- a/index.js
+++ b/index.js
@@ -3,34 +3,33 @@ const github = require('@actions/github');
 const Octokit = require("@octokit/rest");
 const minimatch = require('minimatch');
 
-try {
+async(() => {
   const ghToken = core.getInput('github_token');
   const octokit = new Octokit(ghToken ? { auth: ghToken } : {});
   const paths = core.getInput('paths').split(',');
-  const returnFiles = core.getInput('return_files') === 'true';
+
   // When using pull_request, the context payload.head_commit is undefined. But we have after instead.
   const ref = github.context.payload.head_commit ?
     github.context.payload.head_commit.id : github.context.payload.after;
+
+  if (!ref) {
+    core.setOutput('modified', true);
+    return
+  }
+
   const [owner, repo] = github.context.payload.repository.full_name.split('/');
-  octokit.repos.getCommit({ owner, repo, ref })
-    .then(({ data: { files } }, err) => {
-      if (err) throw new Error(err);
-      if (Array.isArray(files)) {
-        const modifiedPaths = files.map(f => f.filename);
-        if(!returnFiles) {
-          const modified = paths.some(p => minimatch.match(modifiedPaths, p).length);
-          core.setOutput('modified', modified);
-        } else {
-          const modified_files = paths.flatMap(p => minimatch.match(modifiedPaths, p));
-          core.setOutput('modified', modified_files.length > 0);
-          core.setOutput('modified_files', modified_files);
-        }
-      } else {
-        core.setOutput('modified', false);
-      }
-  });
-} catch (error) {
-  core.setFailed(error.message);
-  // When we error, we set modified to true to make sure the tests run.
-  core.setOutput('modified', true);
-}
+  const { data: { files }, err } = await octokit.repos.getCommit({ owner, repo, ref })
+  if (err) {
+    console.error(err);
+    core.setOutput('modified', true);
+    return
+  }
+
+  if (Array.isArray(files)) {
+    const modified = paths.some(p => minimatch.match(modifiedPaths, p).length);
+    core.setOutput('modified', modified);
+    return
+  }
+
+  core.setOutput('modified', false);
+})();

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const github = require('@actions/github');
 const Octokit = require("@octokit/rest");
 const minimatch = require('minimatch');
 
-async(() => {
+(async () => {
   const ghToken = core.getInput('github_token');
   const octokit = new Octokit(ghToken ? { auth: ghToken } : {});
   const paths = core.getInput('paths').split(',');


### PR DESCRIPTION
When triggered by pull_request event, the context payload.head_commit is undefined.

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>